### PR TITLE
Specify the language choice for binding scripts

### DIFF
--- a/payjoin-ffi/dart/scripts/bindgen_generate.sh
+++ b/payjoin-ffi/dart/scripts/bindgen_generate.sh
@@ -1,0 +1,11 @@
+
+
+#!/bin/bash
+chmod +x ./scripts/generate_linux.sh
+chmod +x ./scripts/generate_macos.sh
+
+
+# Run each script
+scripts/generate_linux.sh
+scripts/generate_macos.sh
+

--- a/payjoin-ffi/dart/scripts/generate_linux.sh
+++ b/payjoin-ffi/dart/scripts/generate_linux.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+LIBNAME=libpayjoin_ffi.so
+LINUX_TARGET=x86_64-unknown-linux-gnu
+
+echo "Generating payjoin_ffi.dart..."
+cd ../
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release --features uniffi,_test-utils
+cargo run --profile release --features uniffi,_test-utils --bin uniffi-bindgen -- --library target/release/$LIBNAME --language dart --out-dir dart/lib/
+
+echo "Generating native binaries..."
+rustup target add $LINUX_TARGET
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release-smaller --target $LINUX_TARGET --features uniffi,_test-utils
+
+echo "Copying linux payjoin_ffi.so"
+cp target/$LINUX_TARGET/release-smaller/$LIBNAME dart/lib/$LIBNAME
+
+echo "All done!"

--- a/payjoin-ffi/dart/scripts/generate_macos.sh
+++ b/payjoin-ffi/dart/scripts/generate_macos.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+python3 --version
+pip install -r requirements.txt -r requirements-dev.txt
+LIBNAME=libpayjoin_ffi.dylib
+
+echo "Generating payjoin_ffi.dart..."
+cd ../
+# This is a test script the actual release should not include the test utils feature
+cargo build --features uniffi,_test-utils --profile release 
+cargo run --features uniffi,_test-utils --profile release --bin uniffi-bindgen -- --library target/release/$LIBNAME --language dart --out-dir dart/lib/
+
+echo "Generating native binaries..."
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release-smaller --target aarch64-apple-darwin --features uniffi,_test-utils
+echo "Done building aarch64-apple-darwin"
+
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release-smaller --target x86_64-apple-darwin --features uniffi,_test-utils
+echo "Done building x86_64-apple-darwin"
+
+echo "Building macos fat library"
+
+lipo -create -output dart/lib/payjoin/$LIBNAME \
+        target/aarch64-apple-darwin/release-smaller/$LIBNAME \
+        target/x86_64-apple-darwin/release-smaller/$LIBNAME
+
+
+echo "All done!"

--- a/payjoin-ffi/uniffi-bindgen.rs
+++ b/payjoin-ffi/uniffi-bindgen.rs
@@ -1,13 +1,39 @@
+use std::env;
+
 fn main() {
-    #[cfg(feature = "uniffi")]
-    uniffi::uniffi_bindgen_main();
-    #[cfg(feature = "uniffi")]
-    uniffi_dart::gen::generate_dart_bindings(
-        "src/payjoin_ffi.udl".into(),
-        None,
-        Some("dart/lib".into()),
-        "target/release/libpayjoin_ffi.dylib".into(),
-        true,
-    )
-    .unwrap();
+    let args: Vec<String> = env::args().collect();
+
+    let language =
+        args.iter().position(|arg| arg == "--language").and_then(|idx| args.get(idx + 1));
+
+    match language {
+        Some(lang) if lang == "dart" => {
+            #[cfg(feature = "uniffi")]
+            uniffi_dart::gen::generate_dart_bindings(
+                "src/payjoin_ffi.udl".into(),
+                None,
+                Some(
+                    args.iter()
+                        .position(|arg| arg == "--out-dir")
+                        .and_then(|idx| args.get(idx + 1))
+                        .expect("No output directory found")
+                        .as_str()
+                        .into(),
+                ),
+                args.iter()
+                    .position(|arg| arg == "--library")
+                    .and_then(|idx| args.get(idx + 1))
+                    .expect("No target file found")
+                    .as_str()
+                    .into(),
+                true,
+            )
+            .expect("Failed to generate dart bindings");
+        }
+        Some(lang) if lang == "python" => {
+            #[cfg(feature = "uniffi")]
+            uniffi::uniffi_bindgen_main();
+        }
+        _ => panic!("No language specified"),
+    }
 }


### PR DESCRIPTION
This has changed slightly since this PR was first opened but I decided to keep this instead of closing, but in essence we are now just separating the uniffi-dart and uniffi-rs bindings as separate scripts.