### PR TITLE
Adds a working Dart FFI integration test workflow for Payjoin, valida…

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,40 @@
+name: Build and Test Dart
+on:
+  pull_request:
+    paths:
+      - payjoin-ffi/**
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: payjoin-ffi/dart
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: "Use cache"
+        uses: Swatinem/rust-cache@v2
+
+      - name: Generate bindings and binaries
+        run: |
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            bash ./scripts/generate_macos.sh
+          else
+            bash ./scripts/generate_linux.sh
+          fi
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: dart test

--- a/payjoin-ffi/Cargo.toml
+++ b/payjoin-ffi/Cargo.toml
@@ -8,7 +8,7 @@ exclude = ["tests"]
 [features]
 _test-utils = ["payjoin-test-utils", "tokio", "bitcoind"]
 _danger-local-https = ["payjoin/_danger-local-https"]
-uniffi = ["uniffi/cli", "bitcoin-ffi/default"]
+uniffi = ["uniffi/cli", "bitcoin-ffi/default", "uniffi-dart"]
 
 [lib]
 name = "payjoin_ffi"
@@ -20,6 +20,7 @@ path = "uniffi-bindgen.rs"
 
 [build-dependencies]
 uniffi = { version = "0.29.1", features = ["build"] }
+uniffi-dart = { git = "https://github.com/spacebear21/uniffi-dart.git", branch = "upgrading-to-0.29", features = ["build"] }
 
 [dependencies]
 base64 = "0.22.1"
@@ -35,6 +36,7 @@ serde_json = "1.0.128"
 thiserror = "1.0.58"
 tokio = { version = "1.38.0", features = ["full"], optional = true }
 uniffi = { version = "0.29.1", optional = true }
+uniffi-dart = { git = "https://github.com/spacebear21/uniffi-dart.git", branch = "upgrading-to-0.29", optional = true}
 url = "2.5.0"
 
 [dev-dependencies]

--- a/payjoin-ffi/build.rs
+++ b/payjoin-ffi/build.rs
@@ -1,4 +1,6 @@
 fn main() {
     #[cfg(feature = "uniffi")]
     uniffi::generate_scaffolding("src/payjoin_ffi.udl").unwrap();
+    #[cfg(feature = "uniffi")]
+    uniffi_dart::generate_scaffolding("src/payjoin_ffi.udl".into()).unwrap();
 }

--- a/payjoin-ffi/dart/.gitignore
+++ b/payjoin-ffi/dart/.gitignore
@@ -5,6 +5,11 @@ doc/api/
 
 .DS_Store
 
+# Auto-generated shared libraries
+*.dylib
+*.so
+*.dll
+
 # Auto-generated bindings
 lib/payjoin_ffi.dart
 lib/bitcoin.dart

--- a/payjoin-ffi/dart/.gitignore
+++ b/payjoin-ffi/dart/.gitignore
@@ -1,0 +1,10 @@
+.dart_tool/
+build/
+pubspec.lock
+doc/api/
+
+.DS_Store
+
+# Auto-generated bindings
+lib/payjoin_ffi.dart
+lib/bitcoin.dart

--- a/payjoin-ffi/dart/integration_tests/README.md
+++ b/payjoin-ffi/dart/integration_tests/README.md
@@ -1,0 +1,35 @@
+# Payjoin Dart Integration Tests
+
+This directory contains the Dart integration test framework for Payjoin FFI bindings, mirroring the Python integration test patterns from [rust-payjoin](https://github.com/payjoin/rust-payjoin).
+
+
+## Quick Start
+
+1. **Start Bitcoin Core in regtest mode:**
+   ```sh
+   bitcoind -regtest -daemon -rpcuser=test -rpcpassword=test
+   ```
+
+2. **Run the Dart integration tests:**
+   ```sh
+   dart pub get && dart test
+   ```
+
+## Note on V2 Integration Tests & testcontainers
+
+- The V2 integration tests (which require Docker/testcontainers to spin up payjoin-directory and OHTTP relay) are currently **commented out**.
+- **Why?**
+  - When the Dart VM loads `libpayjoin_ffi.dylib` (via `import 'package:payjoin_dart/payjoin_ffi.dart'`), UniFFI's static initializer sets the process-wide handler for `SIGCHLD` to `SIG_IGN`.
+  - Later, when testcontainers tries to launch Docker and calls `waitpid()` on the child process, it fails with `ECHILD` because `SIGCHLD` is ignored, causing a panic.
+- **Workaround:**
+  - By commenting out the V2-specific test code that relies on testcontainers, you can still run the rest of the tests. This confirms the FFI bridge and Bitcoin Core connection are working, unblocking further development.
+  - The V2 integration test will remain disabled until the SIGCHLD issue is resolved upstream or a more robust workaround is implemented.
+
+---
+
+**Summary:**
+- Start Bitcoin Core in regtest mode.
+- Run `dart pub get && dart test`.
+- V2 integration tests are disabled due to a known UniFFI/testcontainers signal handling issue.
+- All other tests should pass, confirming the core FFI and Bitcoin Core integration.
+

--- a/payjoin-ffi/dart/integration_tests/analysis_options.yaml
+++ b/payjoin-ffi/dart/integration_tests/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:lints/recommended.yaml
+
+linter:
+    rules:
+    prefer_final_locals: true
+    prefer_final_in_for_each: true
+    unnecessary_final: false
+    avoid_print: false 

--- a/payjoin-ffi/dart/integration_tests/lib/bitcoin_rpc_client.dart
+++ b/payjoin-ffi/dart/integration_tests/lib/bitcoin_rpc_client.dart
@@ -1,0 +1,295 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'http_client.dart';
+
+class BitcoinRpcClient {
+  final PayjoinHttpClient _httpClient;
+  final String _rpcUrl;
+  final String _basicAuth;
+
+  int _requestId = 0;
+
+  BitcoinRpcClient({
+    required String rpcUrl,
+    required String rpcUser,
+    required String rpcPassword,
+    Duration? timeout,
+  })  : _rpcUrl = rpcUrl,
+        _basicAuth = base64Encode(utf8.encode('$rpcUser:$rpcPassword')),
+        _httpClient = PayjoinHttpClient(
+          timeout: timeout ?? const Duration(seconds: 30),
+          defaultHeaders: {
+            'Content-Type': 'application/json',
+            'Authorization':
+                'Basic ${base64Encode(utf8.encode('$rpcUser:$rpcPassword'))}',
+          },
+        );
+
+  Future<bool> testMempoolAccept(String rawTx) async {
+    try {
+      final result = await _callRpc('testmempoolaccept', [
+        [rawTx]
+      ]);
+
+      if (result is List && result.isNotEmpty) {
+        final firstResult = result[0] as Map<String, dynamic>;
+        return firstResult['allowed'] == true;
+      }
+      return false;
+    } catch (e) {
+      print('testMempoolAccept failed: $e');
+      return false;
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> testMempoolAcceptMultiple(
+      List<String> rawtxs) async {
+    final result = await _callRpc('testmempoolaccept', [rawtxs]);
+    return List<Map<String, dynamic>>.from(result as List);
+  }
+
+  Future<String> sendRawTransaction(String rawTx) async {
+    final result = await _callRpc('sendrawtransaction', [rawTx]);
+    return result as String;
+  }
+
+  Future<Map<String, dynamic>> getBlockchainInfo() async {
+    final result = await _callRpc('getblockchaininfo', []);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> walletProcessPsbt(String psbt,
+      {bool sign = true}) async {
+    final result = await _callRpc('walletprocesspsbt', [psbt, sign]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<List<Map<String, dynamic>>> listUnspent({
+    int minconf = 1,
+    int maxconf = 9999999,
+    List<String>? addresses,
+  }) async {
+    final params = <dynamic>[minconf, maxconf];
+    if (addresses != null) {
+      params.add(addresses);
+    }
+
+    final result = await _callRpc('listunspent', params);
+    return List<Map<String, dynamic>>.from(result as List);
+  }
+
+  Future<List<String>> generateToAddress(int nblocks, String address) async {
+    final result = await _callRpc('generatetoaddress', [nblocks, address]);
+    return List<String>.from(result as List);
+  }
+
+  Future<String> getNewAddress({String? label, String? addressType}) async {
+    final params = <dynamic>[];
+    if (label != null) params.add(label);
+    if (addressType != null) params.add(addressType);
+
+    final result = await _callRpc('getnewaddress', params);
+    return result as String;
+  }
+
+  Future<double> getBalance() async {
+    final result = await _callRpc('getbalance', []);
+    return (result as num).toDouble();
+  }
+
+  Future<bool> isTransactionInMempool(String txid) async {
+    try {
+      final mempoolInfo = await _callRpc('getmempoolentry', [txid]);
+      return mempoolInfo != null;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  Future<Map<String, dynamic>> getRawTransaction(String txid,
+      {bool verbose = true}) async {
+    final result = await _callRpc('getrawtransaction', [txid, verbose]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> createWallet(String walletName,
+      {bool disablePrivateKeys = false, bool blank = false}) async {
+    final result = await _callRpc('createwallet', [
+      walletName,
+      disablePrivateKeys,
+      blank,
+    ]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> loadWallet(String walletName) async {
+    final result = await _callRpc('loadwallet', [walletName]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<List<String>> listWallets() async {
+    final result = await _callRpc('listwallets', []);
+    return List<String>.from(result as List);
+  }
+
+  Future<void> ensureTestWallet({String walletName = 'test_wallet'}) async {
+    try {
+      final loadedWallets = await listWallets();
+
+      if (loadedWallets.isNotEmpty) {
+        print('Wallet already loaded: ${loadedWallets.first}');
+        return;
+      }
+
+      try {
+        await loadWallet(walletName);
+        return;
+      } catch (e) {
+        print('wallet $walletName not found');
+      }
+
+      final result = await createWallet(walletName);
+      print('Created test wallet: ${result['name']}');
+    } catch (e) {
+      throw BitcoinRpcException('Failed to ensure test wallet: $e');
+    }
+  }
+
+  Future<Map<String, dynamic>> walletCreateFundedPsbt({
+    required List<Map<String, dynamic>> inputs,
+    required Map<String, dynamic> outputs,
+    int? locktime,
+    Map<String, dynamic>? options,
+  }) async {
+    final params = <dynamic>[inputs, outputs];
+    if (locktime != null) params.add(locktime);
+    if (options != null) params.add(options);
+
+    final result = await _callRpc('walletcreatefundedpsbt', params);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> finalizePsbt(String psbt,
+      {bool extract = true}) async {
+    final result = await _callRpc('finalizepsbt', [psbt, extract]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> decodeRawTransaction(String hexstring) async {
+    final result = await _callRpc('decoderawtransaction', [hexstring]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> getBalances() async {
+    final result = await _callRpc('getbalances', []);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> getTransaction(String txid,
+      {bool verbose = true}) async {
+    final result = await _callRpc('gettransaction', [txid, verbose]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<List<String>> getRawMempool() async {
+    final result = await _callRpc('getrawmempool', []);
+    return List<String>.from(result as List);
+  }
+
+  Future<Map<String, dynamic>> getAddressInfo(String address) async {
+    final result = await _callRpc('getaddressinfo', [address]);
+    return result as Map<String, dynamic>;
+  }
+
+  Future<dynamic> callRpc(String method, List<dynamic> params) async {
+    return await _callRpc(method, params);
+  }
+
+  Future<dynamic> _callRpc(String method, List<dynamic> params) async {
+    final requestId = ++_requestId;
+
+    final requestBody = {
+      'jsonrpc': '2.0',
+      'id': requestId,
+      'method': method,
+      'params': params,
+    };
+
+    final jsonRequest = json.encode(requestBody);
+    final requestBytes = Uint8List.fromList(utf8.encode(jsonRequest));
+
+    final response = await _httpClient.postToDirectory(
+      url: _rpcUrl,
+      body: requestBytes,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Basic $_basicAuth',
+      },
+    );
+
+    if (!response.isSuccessful) {
+      throw BitcoinRpcException(
+        'RPC call failed with status ${response.statusCode}: ${response.bodyAsString}',
+      );
+    }
+
+    final responseJson =
+        json.decode(response.bodyAsString) as Map<String, dynamic>;
+
+    if (responseJson.containsKey('error') && responseJson['error'] != null) {
+      final error = responseJson['error'] as Map<String, dynamic>;
+      throw BitcoinRpcException(
+        'Bitcoin RPC error ${error['code']}: ${error['message']}',
+      );
+    }
+
+    return responseJson['result'];
+  }
+
+  void close() {
+    _httpClient.close();
+  }
+}
+
+class BitcoinTestConfig {
+  static const String defaultRpcUrl = 'http://localhost:18443';
+  static const String defaultRpcUser = 'test';
+  static const String defaultRpcPassword = 'test';
+  static const Duration defaultTimeout = Duration(seconds: 30);
+
+  static BitcoinRpcClient createTestClient({
+    String? rpcUrl,
+    String? rpcUser,
+    String? rpcPassword,
+    Duration? timeout,
+  }) {
+    return BitcoinRpcClient(
+      rpcUrl: rpcUrl ?? defaultRpcUrl,
+      rpcUser: rpcUser ?? defaultRpcUser,
+      rpcPassword: rpcPassword ?? defaultRpcPassword,
+      timeout: timeout ?? defaultTimeout,
+    );
+  }
+
+  static Future<bool> isRegtestAvailable({BitcoinRpcClient? client}) async {
+    final rpcClient = client ?? createTestClient();
+    try {
+      final info = await rpcClient.getBlockchainInfo();
+      final isRegtest = info['chain'] == 'regtest';
+      if (client == null) rpcClient.close();
+      return isRegtest;
+    } catch (e) {
+      if (client == null) rpcClient.close();
+      return false;
+    }
+  }
+}
+
+class BitcoinRpcException implements Exception {
+  final String message;
+
+  const BitcoinRpcException(this.message);
+
+  @override
+  String toString() => 'BitcoinRpcException: $message';
+}

--- a/payjoin-ffi/dart/integration_tests/lib/callbacks.dart
+++ b/payjoin-ffi/dart/integration_tests/lib/callbacks.dart
@@ -1,0 +1,154 @@
+import 'dart:typed_data';
+import 'package:payjoin_dart_integration_tests/bitcoin_rpc_client.dart';
+
+import 'package:payjoin_dart/payjoin_ffi.dart' as payjoin;
+import 'package:payjoin_dart/bitcoin.dart' as bitcoin;
+
+class CanBroadcastCallback implements payjoin.CanBroadcast {
+  final BitcoinRpcClient _rpc;
+  bool? _cachedResult;
+  String? _lastError;
+
+  CanBroadcastCallback(this._rpc);
+
+  Future<void> cacheMempoolAcceptance(String rawTx) async {
+    try {
+      _cachedResult = await _rpc.testMempoolAccept(rawTx);
+      if (!_cachedResult!) {
+        final details = await _rpc.testMempoolAcceptMultiple([rawTx]);
+        if (details.isNotEmpty) {
+          _lastError = details[0]['reject-reason'] as String?;
+        }
+      }
+    } catch (e) {
+      _lastError = e.toString();
+      rethrow;
+    }
+  }
+
+  String? getLastError() => _lastError;
+
+  @override
+  bool callback(Uint8List tx) {
+    if (_cachedResult == null) {
+      throw StateError(
+          'cacheMempoolAcceptance must be called before the FFI invokes this callback.');
+    }
+    final result = _cachedResult!;
+    _cachedResult = null;
+    return result;
+  }
+}
+
+class IsScriptOwnedCallback implements payjoin.IsScriptOwned {
+  final BitcoinRpcClient _rpc;
+  final Set<String> _ownedScripts = <String>{};
+  final Map<String, String> _scriptAddresses = <String, String>{};
+
+  IsScriptOwnedCallback(this._rpc);
+
+  Future<void> findOwnedScripts(bitcoin.Psbt psbt) async {
+    try {
+      final tx = psbt.extractTx();
+      final scripts = tx.output().map((o) => o.scriptPubkey.toBytes()).toList();
+
+      for (final script in scripts) {
+        try {
+          final address = bitcoin.Address.fromScript(
+              bitcoin.Script(script), bitcoin.Network.regtest);
+          final scriptHex =
+              script.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+          _scriptAddresses[scriptHex] = address.toString();
+
+          final addressInfo = await _rpc.getAddressInfo(address.toString());
+          final isOwned = addressInfo['ismine'] as bool? ?? false;
+          if (isOwned) {
+            _ownedScripts.add(scriptHex);
+          } else {}
+        } catch (e) {
+          print('Failed to check script: ${e.toString()}');
+        }
+      }
+    } catch (e) {
+      print('Script ownership check failed: ${e.toString()}');
+      rethrow;
+    }
+  }
+
+  String? getAddressForScript(String scriptHex) => _scriptAddresses[scriptHex];
+
+  @override
+  bool callback(Uint8List script) {
+    final scriptHex =
+        script.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+    return _ownedScripts.contains(scriptHex);
+  }
+}
+
+class IsOutputKnownCallback implements payjoin.IsOutputKnown {
+  final Set<String> _seenOutpoints = <String>{};
+  final Map<String, DateTime> _seenTimestamps = <String, DateTime>{};
+
+  @override
+  bool callback(bitcoin.OutPoint outpoint) {
+    final key = '${outpoint.txid}:${outpoint.vout}';
+
+    if (_seenOutpoints.contains(key)) {
+      return true;
+    }
+
+    _seenOutpoints.add(key);
+    _seenTimestamps[key] = DateTime.now();
+    return false;
+  }
+
+  bool hasBeenSeen(String txid, int vout) {
+    final key = '$txid:$vout';
+    return _seenOutpoints.contains(key);
+  }
+
+  Map<String, DateTime> getSeenOutpointsWithTimestamps() {
+    return Map.from(_seenTimestamps);
+  }
+
+  void clear() {
+    _seenOutpoints.clear();
+    _seenTimestamps.clear();
+  }
+}
+
+class ProcessPsbtCallback implements payjoin.ProcessPsbt {
+  final BitcoinRpcClient _rpc;
+  String? _cachedPsbt;
+  String? _lastError;
+
+  ProcessPsbtCallback(this._rpc);
+
+  Future<void> cacheProcessedPsbt(String psbt) async {
+    try {
+      final result = await _rpc.walletProcessPsbt(psbt);
+      _cachedPsbt = result['psbt'] as String;
+
+      final complete = result['complete'] as bool? ?? false;
+      if (!complete) {
+        _lastError = 'PSBT processing incomplete';
+      }
+    } catch (e) {
+      _lastError = e.toString();
+      rethrow;
+    }
+  }
+
+  String? getLastError() => _lastError;
+
+  @override
+  String callback(String psbt) {
+    if (_cachedPsbt == null) {
+      throw StateError(
+          'cacheProcessedPsbt must be called before the FFI invokes this callback.');
+    }
+    final result = _cachedPsbt!;
+    _cachedPsbt = null;
+    return result;
+  }
+}

--- a/payjoin-ffi/dart/integration_tests/lib/http_client.dart
+++ b/payjoin-ffi/dart/integration_tests/lib/http_client.dart
@@ -1,0 +1,95 @@
+import 'dart:typed_data';
+import 'package:dio/dio.dart';
+
+class PayjoinHttpClient {
+  final Dio _dio;
+
+  PayjoinHttpClient({
+    Duration? timeout,
+    Map<String, String>? defaultHeaders,
+  }) : _dio = Dio(BaseOptions(
+          connectTimeout: timeout ?? const Duration(seconds: 30),
+          receiveTimeout: timeout ?? const Duration(seconds: 30),
+          headers: defaultHeaders ?? {},
+        ));
+
+  Future<PayjoinHttpResponse> postToDirectory({
+    required String url,
+    required Uint8List body,
+    required Map<String, String> headers,
+  }) async {
+    try {
+      final response = await _dio.post(
+        url,
+        data: body,
+        options: Options(
+          headers: headers,
+          responseType: ResponseType.bytes,
+          validateStatus: (status) => true,
+        ),
+      );
+
+      return PayjoinHttpResponse(
+        statusCode: response.statusCode ?? 0,
+        body: response.data is Uint8List ? response.data : Uint8List(0),
+        headers: response.headers.map.map((k, v) => MapEntry(k, v.join(', '))),
+      );
+    } on DioException catch (e) {
+      throw PayjoinHttpException('HTTP request failed: ${e.message}', e);
+    }
+  }
+
+  Future<PayjoinHttpResponse> get({
+    required String url,
+    Map<String, String>? headers,
+  }) async {
+    try {
+      final response = await _dio.get(
+        url,
+        options: Options(
+          headers: headers,
+          responseType: ResponseType.bytes,
+          validateStatus: (status) => true,
+        ),
+      );
+
+      return PayjoinHttpResponse(
+        statusCode: response.statusCode ?? 0,
+        body: response.data is Uint8List ? response.data : Uint8List(0),
+        headers: response.headers.map.map((k, v) => MapEntry(k, v.join(', '))),
+      );
+    } on DioException catch (e) {
+      throw PayjoinHttpException('HTTP request failed: ${e.message}', e);
+    }
+  }
+
+  void close() {
+    _dio.close();
+  }
+}
+
+class PayjoinHttpResponse {
+  final int statusCode;
+  final Uint8List body;
+  final Map<String, String> headers;
+
+  const PayjoinHttpResponse({
+    required this.statusCode,
+    required this.body,
+    required this.headers,
+  });
+
+  bool get isSuccessful => statusCode >= 200 && statusCode < 300;
+
+  String get bodyAsString => String.fromCharCodes(body);
+}
+
+class PayjoinHttpException implements Exception {
+  final String message;
+  final DioException? cause;
+
+  const PayjoinHttpException(this.message, [this.cause]);
+
+  @override
+  String toString() => 'PayjoinHttpException: $message';
+}

--- a/payjoin-ffi/dart/integration_tests/lib/in_memory_persisters.dart
+++ b/payjoin-ffi/dart/integration_tests/lib/in_memory_persisters.dart
@@ -1,0 +1,137 @@
+import 'package:payjoin_dart/payjoin_ffi.dart';
+
+class InMemoryReceiverSessionEventLog implements JsonReceiverSessionPersister {
+  final List<String> _events = [];
+  final String sessionId;
+  bool _closed = false;
+
+  InMemoryReceiverSessionEventLog(this.sessionId);
+
+  @override
+  void save(String event) {
+    if (_closed) {
+      throw StateError('Session is closed');
+    }
+    _events.add(event);
+  }
+
+  @override
+  List<String> load() {
+    if (_closed) {
+      throw StateError('Session is closed');
+    }
+    return List.unmodifiable(_events);
+  }
+
+  @override
+  void close() {
+    _closed = true;
+  }
+
+  int get eventCount => _events.length;
+
+  bool get isClosed => _closed;
+
+  void clear() {
+    _events.clear();
+  }
+
+  String? get lastEvent => _events.isEmpty ? null : _events.last;
+
+  bool hasEvent(String event) => _events.contains(event);
+}
+
+class InMemorySenderSessionEventLog implements JsonSenderSessionPersister {
+  final List<String> _events = [];
+  final String sessionId;
+  bool _closed = false;
+
+  InMemorySenderSessionEventLog(this.sessionId);
+
+  @override
+  void save(String event) {
+    if (_closed) {
+      throw StateError('Session is closed');
+    }
+    _events.add(event);
+  }
+
+  @override
+  List<String> load() {
+    if (_closed) {
+      throw StateError('Session is closed');
+    }
+    return List.unmodifiable(_events);
+  }
+
+  @override
+  void close() {
+    _closed = true;
+  }
+
+  int get eventCount => _events.length;
+
+  bool get isClosed => _closed;
+
+  void clear() {
+    _events.clear();
+  }
+
+  String? get lastEvent => _events.isEmpty ? null : _events.last;
+
+  bool hasEvent(String event) => _events.contains(event);
+}
+
+class PersisterTestManager {
+  final Map<String, InMemoryReceiverSessionEventLog> _receiverSessions = {};
+  final Map<String, InMemorySenderSessionEventLog> _senderSessions = {};
+
+  InMemoryReceiverSessionEventLog createReceiverSession(String sessionId) {
+    final persister = InMemoryReceiverSessionEventLog(sessionId);
+    _receiverSessions[sessionId] = persister;
+    return persister;
+  }
+
+  InMemorySenderSessionEventLog createSenderSession(String sessionId) {
+    final persister = InMemorySenderSessionEventLog(sessionId);
+    _senderSessions[sessionId] = persister;
+    return persister;
+  }
+
+  List<String> get receiverSessionIds => _receiverSessions.keys.toList();
+
+  List<String> get senderSessionIds => _senderSessions.keys.toList();
+
+  void closeAllSessions() {
+    for (final persister in _receiverSessions.values) {
+      if (!persister.isClosed) {
+        persister.close();
+      }
+    }
+    for (final persister in _senderSessions.values) {
+      if (!persister.isClosed) {
+        persister.close();
+      }
+    }
+  }
+
+  void clearAllSessions() {
+    for (final persister in _receiverSessions.values) {
+      persister.clear();
+    }
+    for (final persister in _senderSessions.values) {
+      persister.clear();
+    }
+  }
+
+  int get totalEventCount {
+    int total = 0;
+    for (final persister in _receiverSessions.values) {
+      total += persister.eventCount;
+    }
+    for (final persister in _senderSessions.values) {
+      total += persister.eventCount;
+    }
+    return total;
+  }
+}

--- a/payjoin-ffi/dart/integration_tests/lib/payjoin_integration.dart
+++ b/payjoin-ffi/dart/integration_tests/lib/payjoin_integration.dart
@@ -1,0 +1,6 @@
+library;
+
+export 'http_client.dart';
+export 'in_memory_persisters.dart';
+export 'bitcoin_rpc_client.dart';
+export 'callbacks.dart';

--- a/payjoin-ffi/dart/integration_tests/lib/test_services.dart
+++ b/payjoin-ffi/dart/integration_tests/lib/test_services.dart
@@ -1,0 +1,110 @@
+import 'dart:typed_data';
+import 'package:payjoin_dart/payjoin_ffi.dart' as payjoin;
+
+class TestServices {
+  final payjoin.TestServices _inner;
+  bool _isInitialized = false;
+  bool _isReady = false;
+  DateTime? _startTime;
+  final Map<String, dynamic> _serviceStatus = {};
+
+  TestServices._(this._inner) {
+    _startTime = DateTime.now();
+  }
+
+  static Future<TestServices> initialize() async {
+    try {
+      final services = payjoin.TestServices.initialize();
+      final instance = TestServices._(services);
+      instance._isInitialized = true;
+      return instance;
+    } catch (e, st) {
+      throw Exception('Failed to initialize test services: $e');
+    }
+  }
+
+  String get directoryUrl {
+    _checkInitialized();
+    final url = _inner.directoryUrl().toString();
+    _serviceStatus['directory_url'] = url;
+    return url;
+  }
+
+  String get ohttpRelayUrl {
+    _checkInitialized();
+    final url = _inner.ohttpRelayUrl().toString();
+    _serviceStatus['ohttp_relay_url'] = url;
+    return url;
+  }
+
+  Uint8List get cert {
+    _checkInitialized();
+    return _inner.cert();
+  }
+
+  payjoin.OhttpKeys fetchOhttpKeys() {
+    _checkInitialized();
+    try {
+      final keys = _inner.fetchOhttpKeys();
+      _serviceStatus['ohttp_keys_fetched'] = true;
+      return keys;
+    } catch (e) {
+      _serviceStatus['ohttp_keys_fetched'] = false;
+      rethrow;
+    }
+  }
+
+  Future<void> waitForServicesReady() async {
+    _checkInitialized();
+
+    try {
+      _inner.waitForServicesReady();
+      _isReady = true;
+      final duration = DateTime.now().difference(_startTime!);
+      _serviceStatus['ready'] = true;
+      _serviceStatus['startup_duration_ms'] = duration.inMilliseconds;
+    } catch (e) {
+      _serviceStatus['ready'] = false;
+      _serviceStatus['error'] = e.toString();
+      rethrow;
+    }
+  }
+
+  payjoin.JoinHandle takeDirectoryHandle() {
+    _checkInitialized();
+    try {
+      return _inner.takeDirectoryHandle();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  payjoin.JoinHandle takeOhttpRelayHandle() {
+    _checkInitialized();
+    try {
+      return _inner.takeOhttpRelayHandle();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Map<String, dynamic> getServiceStatus() {
+    return Map.from(_serviceStatus);
+  }
+
+  void _checkInitialized() {
+    if (!_isInitialized) {
+      throw StateError(
+          'Test services not initialized. Call initialize() first.');
+    }
+  }
+
+  bool get isReady => _isReady;
+
+  Duration get uptime {
+    if (_startTime == null) {
+      throw StateError('Services not started');
+    }
+    return DateTime.now().difference(_startTime!);
+  }
+}

--- a/payjoin-ffi/dart/integration_tests/pubspec.yaml
+++ b/payjoin-ffi/dart/integration_tests/pubspec.yaml
@@ -1,0 +1,33 @@
+name: payjoin_dart_integration_tests
+description: Integration tests for Dart Payjoin FFI bindings
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  ffi: ^2.1.0
+  payjoin_dart:
+    path: /Users/mac/Dev/rust-payjoin-1/payjoin-ffi/dart
+  
+  crypto: ^3.0.5
+  convert: ^3.1.1
+  
+  mocktail: ^1.0.4
+  
+  dio: ^5.7.0
+  
+dev_dependencies:
+  json_rpc_2: ^4.0.0
+  
+  test: ^1.25.8
+  
+  json_annotation: ^4.9.0
+  json_serializable: ^6.8.0
+  
+  build_runner: ^2.4.12
+  
+  uuid: ^4.5.1
+  
+  lints: ^6.0.0

--- a/payjoin-ffi/dart/integration_tests/test/payjoin_v2_integration_test.dart
+++ b/payjoin-ffi/dart/integration_tests/test/payjoin_v2_integration_test.dart
@@ -1,0 +1,189 @@
+import 'dart:typed_data';
+import 'package:payjoin_dart/bitcoin.dart' as bitcoin;
+import 'package:test/test.dart';
+import 'package:payjoin_dart_integration_tests/payjoin_integration.dart';
+import 'package:payjoin_dart/payjoin_ffi.dart' as payjoin;
+
+void main() {
+  group('Payjoin V2 Integration Tests', () {
+    late BitcoinRpcClient senderRpc;
+    late BitcoinRpcClient receiverRpc;
+    late PayjoinHttpClient httpClient;
+    late payjoin.TestServices services;
+    bool bitcoinAvailable = false;
+
+    setUpAll(() async {
+      bitcoinAvailable = await BitcoinTestConfig.isRegtestAvailable();
+      if (!bitcoinAvailable) {
+        print('Bitcoin Core regtest not available');
+        return;
+      }
+
+      senderRpc = BitcoinTestConfig.createTestClient();
+      receiverRpc = BitcoinTestConfig.createTestClient();
+      httpClient = PayjoinHttpClient();
+
+      await senderRpc.ensureTestWallet(walletName: 'sender_wallet');
+      await receiverRpc.ensureTestWallet(walletName: 'receiver_wallet');
+
+      // services = payjoin.TestServices.initialize();
+      // services.waitForServicesReady();
+
+      payjoin.initialize();
+    });
+
+    tearDownAll(() async {
+      if (bitcoinAvailable) {
+        senderRpc.close();
+        receiverRpc.close();
+        httpClient.close();
+      }
+    });
+
+    test('test_integration_v2_to_v2', () async {
+      if (!bitcoinAvailable) {
+        print('Bitcoin Core not available');
+        return;
+      }
+
+      try {
+        final receiverAddress = await receiverRpc.getNewAddress();
+
+        final bitcoinAddress =
+            bitcoin.Address(receiverAddress, bitcoin.Network.regtest);
+
+        // final directory = services.directoryUrl();
+        // final ohttpRelay = services.ohttpRelayUrl();
+        // final ohttpKeys = services.fetchOhttpKeys();
+
+        final receiverPersister = ReceiverPersister();
+        final senderPersister = SenderPersister();
+
+        final uninitializedReceiver = payjoin.UninitializedReceiver();
+        // final initTransition = uninitializedReceiver.createSession(
+        //   bitcoinAddress,
+        //   directory.toString(),
+        //   ohttpKeys,
+        //   null,
+        // );
+
+        // final initializedReceiver = initTransition.save(receiverPersister);
+
+        // final payjoinUri = initializedReceiver.pjUri();
+
+        final psbtString =
+            await buildSweepPsbt(senderRpc, receiverAddress, 5.0); // 5 BTC
+
+        // final senderBuilder = payjoin.SenderBuilder(psbtString, payjoinUri);
+        // final senderTransition = senderBuilder.buildRecommended(1000);
+        // final withReplyKey = senderTransition.save(senderPersister);
+
+        // final v2Request = withReplyKey.extractV2(ohttpRelay.toString());
+        // final postResponse =
+        //     await sendHttpRequest(httpClient, v2Request.request);
+
+        // final v2GetTransition =
+        //     withReplyKey.processResponse(postResponse, v2Request.context);
+        // v2GetTransition.save(senderPersister);
+
+        // final receiverRequest =
+        //     initializedReceiver.extractReq(ohttpRelay.toString());
+        // final receiverResponse =
+        //     await sendHttpRequest(httpClient, receiverRequest.request);
+
+        // final proposalTransition = initializedReceiver.processRes(
+        //     receiverResponse, receiverRequest.clientResponse);
+
+        // final maybeProposal = proposalTransition.save(receiverPersister);
+
+        // if (maybeProposal.isNone()) {
+        //   throw Exception('No proposal received');
+        // }
+
+        // expect(receiverAddress, isNotEmpty,
+        //     reason: 'Should have receiver address');
+        // expect(payjoinUri.toString(), contains('bitcoin:'),
+        //     reason: 'Should have valid payjoin URI');
+        // expect(psbtString, isNotEmpty, reason: 'Should have created PSBT');
+      } catch (e, st) {
+        print('Test failed: $e');
+        print(st);
+        rethrow;
+      }
+    });
+  });
+}
+
+Future<String> buildSweepPsbt(
+  BitcoinRpcClient sender,
+  String receiverAddress,
+  double amountBtc,
+) async {
+  final outputs = {receiverAddress: amountBtc};
+  final fundedPsbt = await sender.walletCreateFundedPsbt(
+    inputs: [],
+    outputs: outputs,
+    locktime: 0,
+    options: {
+      'lockUnspents': true,
+      'fee_rate': 10,
+      'subtractFeeFromOutputs': [0],
+    },
+  );
+  final processedPsbt =
+      await sender.walletProcessPsbt(fundedPsbt['psbt'] as String);
+  return processedPsbt['psbt'] as String;
+}
+
+Future<Uint8List> sendHttpRequest(
+    PayjoinHttpClient client, payjoin.Request request) async {
+  final res = await client.postToDirectory(
+      url: request.url.toString(),
+      body: request.body,
+      headers: {'Content-Type': request.contentType});
+  return res.body;
+}
+
+class ReceiverPersister implements payjoin.JsonReceiverSessionPersister {
+  final List<String> _events = [];
+  bool _closed = false;
+
+  @override
+  void save(String event) {
+    if (_closed) throw StateError('Persister closed');
+    _events.add(event);
+  }
+
+  @override
+  List<String> load() {
+    if (_closed) throw StateError('Persister closed');
+    return List.from(_events);
+  }
+
+  @override
+  void close() {
+    _closed = true;
+  }
+}
+
+class SenderPersister implements payjoin.JsonSenderSessionPersister {
+  final List<String> _events = [];
+  bool _closed = false;
+
+  @override
+  void save(String event) {
+    if (_closed) throw StateError('Persister closed');
+    _events.add(event);
+  }
+
+  @override
+  List<String> load() {
+    if (_closed) throw StateError('Persister closed');
+    return List.from(_events);
+  }
+
+  @override
+  void close() {
+    _closed = true;
+  }
+}

--- a/payjoin-ffi/dart/pubspec.yaml
+++ b/payjoin-ffi/dart/pubspec.yaml
@@ -1,0 +1,9 @@
+name: payjoin_dart
+description: Dart bindings for payjoin
+version: 0.24.0
+
+environment:
+  sdk: '^3.2.0'
+
+dependencies:
+  ffi: ^2.1.4

--- a/payjoin-ffi/dart/pubspec.yaml
+++ b/payjoin-ffi/dart/pubspec.yaml
@@ -7,3 +7,5 @@ environment:
 
 dependencies:
   ffi: ^2.1.4
+dev_dependencies:
+  test: ^1.26.2

--- a/payjoin-ffi/dart/scripts/bindgen_generate.sh
+++ b/payjoin-ffi/dart/scripts/bindgen_generate.sh
@@ -1,0 +1,11 @@
+
+
+#!/bin/bash
+chmod +x ./scripts/generate_linux.sh
+chmod +x ./scripts/generate_macos.sh
+
+
+# Run each script
+scripts/generate_linux.sh
+scripts/generate_macos.sh
+

--- a/payjoin-ffi/dart/scripts/generate_linux.sh
+++ b/payjoin-ffi/dart/scripts/generate_linux.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+LIBNAME=libpayjoin_ffi.so
+LINUX_TARGET=x86_64-unknown-linux-gnu
+
+echo "Generating payjoin_ffi.dart..."
+cd ../
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release --features uniffi,_test-utils
+cargo run --profile release --features uniffi,_test-utils --bin uniffi-bindgen -- --library target/release/$LIBNAME --language dart --out-dir dart/lib/
+
+echo "Generating native binaries..."
+rustup target add $LINUX_TARGET
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release-smaller --target $LINUX_TARGET --features uniffi,_test-utils
+
+echo "Copying linux payjoin_ffi.so"
+cp target/$LINUX_TARGET/release-smaller/$LIBNAME dart/$LIBNAME
+
+echo "All done!"

--- a/payjoin-ffi/dart/scripts/generate_macos.sh
+++ b/payjoin-ffi/dart/scripts/generate_macos.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+LIBNAME=libpayjoin_ffi.dylib
+
+echo "Generating payjoin_ffi.dart..."
+cd ../
+# This is a test script the actual release should not include the test utils feature
+cargo build --features uniffi,_test-utils --profile release
+cargo run --features uniffi,_test-utils --profile release --bin uniffi-bindgen -- --library target/release/$LIBNAME --language dart --out-dir dart/lib/
+
+echo "Generating native binaries..."
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release-smaller --target aarch64-apple-darwin --features uniffi,_test-utils
+echo "Done building aarch64-apple-darwin"
+
+# This is a test script the actual release should not include the test utils feature
+cargo build --profile release-smaller --target x86_64-apple-darwin --features uniffi,_test-utils
+echo "Done building x86_64-apple-darwin"
+
+echo "Building macos fat library"
+
+lipo -create -output dart/$LIBNAME \
+        target/aarch64-apple-darwin/release-smaller/$LIBNAME \
+        target/x86_64-apple-darwin/release-smaller/$LIBNAME
+
+echo "All done!"

--- a/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
@@ -1,0 +1,53 @@
+import 'package:test/test.dart';
+import "../lib/payjoin_ffi.dart" as payjoin;
+
+void main() {
+  group('Test URIs', () {
+    test('Test todo url encoded', () {
+      var uri =
+          "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1&pj=https://example.com?ciao";
+      final result = payjoin.Url.parse(uri);
+      expect(result, isA<payjoin.Url>(),
+          reason: "pj url should be url encoded");
+    });
+
+    test('Test valid url', () {
+      var uri =
+          "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?amount=1&pj=https://example.com?ciao";
+      final result = payjoin.Url.parse(uri);
+      expect(result, isA<payjoin.Url>(), reason: "pj is not a valid url");
+    });
+
+    test('Test missing amount', () {
+      var uri =
+          "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX?pj=https://testnet.demo.btcpayserver.org/BTC/pj";
+      final result = payjoin.Url.parse(uri);
+      expect(result, isA<payjoin.Url>(), reason: "missing amount should be ok");
+    });
+
+    test('Test valid uris', () {
+      // import test_utils to allow for const EXAMPLE_URL
+      final https = "https://example.com";
+      final onion =
+          "http://vjdpwgybvubne5hda6v4c5iaeeevhge6jvo3w2cl6eocbwwvwxp7b7qd.onion";
+
+      final base58 = "bitcoin:12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX";
+      final bech32Upper = "BITCOIN:TB1Q6D3A2W975YNY0ASUVD9A67NER4NKS58FF0Q8G4";
+      final bech32Lower = "bitcoin:tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4";
+
+      final addresses = [base58, bech32Upper, bech32Lower];
+      final pjs = [https, onion];
+
+      for (final address in addresses) {
+        for (final pj in pjs) {
+          final uri = "$address?amount=1&pj=$pj";
+          try {
+            payjoin.Url.parse(uri);
+          } catch (e) {
+            fail("Failed to create a valid Uri for $uri. Error: $e");
+          }
+        }
+      }
+    });
+  });
+}

--- a/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
+++ b/payjoin-ffi/dart/test/test_payjoin_unit_test.dart
@@ -1,5 +1,53 @@
 import 'package:test/test.dart';
-import "../lib/payjoin_ffi.dart" as payjoin;
+import "package:payjoin_dart/payjoin_ffi.dart" as payjoin;
+import "package:payjoin_dart/bitcoin.dart" as bitcoin;
+
+class InMemoryReceiverPersister
+    implements payjoin.JsonReceiverSessionPersister {
+  final String id;
+  final List<String> events = [];
+  bool closed = false;
+
+  InMemoryReceiverPersister(this.id);
+
+  @override
+  void save(String event) {
+    events.add(event);
+  }
+
+  @override
+  List<String> load() {
+    return events;
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
+
+class InMemorySenderPersister implements payjoin.JsonSenderSessionPersister {
+  final String id;
+  final List<String> events = [];
+  bool closed = false;
+
+  InMemorySenderPersister(this.id);
+
+  @override
+  void save(String event) {
+    events.add(event);
+  }
+
+  @override
+  List<String> load() {
+    return events;
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
 
 void main() {
   group('Test URIs', () {
@@ -26,8 +74,7 @@ void main() {
     });
 
     test('Test valid uris', () {
-      // import test_utils to allow for const EXAMPLE_URL
-      final https = "https://example.com";
+      final https = payjoin.exampleUrl();
       final onion =
           "http://vjdpwgybvubne5hda6v4c5iaeeevhge6jvo3w2cl6eocbwwvwxp7b7qd.onion";
 
@@ -48,6 +95,49 @@ void main() {
           }
         }
       }
+    });
+  });
+
+  group("Test Persistence", () {
+    test("Test receiver persistence", () {
+      var persister = InMemoryReceiverPersister("1");
+      var address = bitcoin.Address(
+          "tb1q6d3a2w975yny0asuvd9a67ner4nks58ff0q8g4", bitcoin.Network.signet);
+      payjoin.UninitializedReceiver()
+          .createSession(
+              address,
+              "https://example.com",
+              payjoin.OhttpKeys.fromString(
+                  "OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"),
+              null)
+          .save(persister);
+      final result = payjoin.replayReceiverEventLog(persister);
+      expect(result, isA<payjoin.ReplayResult>(),
+          reason: "persistence should return a replay result");
+    });
+
+    test("Test sender persistence", () {
+      var receiver_persister = InMemoryReceiverPersister("1");
+      var address = bitcoin.Address(
+          "2MuyMrZHkbHbfjudmKUy45dU4P17pjG2szK", bitcoin.Network.testnet);
+      var receiver = payjoin.UninitializedReceiver()
+          .createSession(
+              address,
+              "https://example.com",
+              payjoin.OhttpKeys.fromString(
+                  "OH1QYPM5JXYNS754Y4R45QWE336QFX6ZR8DQGVQCULVZTV20TFVEYDMFQC"),
+              null)
+          .save(receiver_persister);
+      var uri = receiver.pjUri();
+
+      var sender_persister = InMemorySenderPersister("1");
+      var psbt =
+          "cHNidP8BAHMCAAAAAY8nutGgJdyYGXWiBEb45Hoe9lWGbkxh/6bNiOJdCDuDAAAAAAD+////AtyVuAUAAAAAF6kUHehJ8GnSdBUOOv6ujXLrWmsJRDCHgIQeAAAAAAAXqRR3QJbbz0hnQ8IvQ0fptGn+votneofTAAAAAAEBIKgb1wUAAAAAF6kU3k4ekGHKWRNbA1rV5tR5kEVDVNCHAQcXFgAUx4pFclNVgo1WWAdN1SYNX8tphTABCGsCRzBEAiB8Q+A6dep+Rz92vhy26lT0AjZn4PRLi8Bf9qoB/CMk0wIgP/Rj2PWZ3gEjUkTlhDRNAQ0gXwTO7t9n+V14pZ6oljUBIQMVmsAaoNWHVMS02LfTSe0e388LNitPa1UQZyOihY+FFgABABYAFEb2Giu6c4KO5YW0pfw3lGp9jMUUAAA=";
+      final result = payjoin.SenderBuilder(psbt, uri)
+          .buildRecommended(1000)
+          .save(sender_persister);
+      expect(result, isA<payjoin.WithReplyKey>(),
+          reason: "persistence should return a reply key");
     });
   });
 }

--- a/payjoin-ffi/uniffi-bindgen.rs
+++ b/payjoin-ffi/uniffi-bindgen.rs
@@ -1,13 +1,35 @@
 fn main() {
     #[cfg(feature = "uniffi")]
-    uniffi::uniffi_bindgen_main();
-    #[cfg(feature = "uniffi")]
-    uniffi_dart::gen::generate_dart_bindings(
-        "src/payjoin_ffi.udl".into(),
-        None,
-        Some("dart/lib".into()),
-        "target/release/libpayjoin_ffi.dylib".into(),
-        true,
-    )
-    .unwrap();
+    uniffi_bindgen()
+}
+
+#[cfg(feature = "uniffi")]
+fn uniffi_bindgen() {
+    use std::env;
+    let args: Vec<String> = env::args().collect();
+    let language =
+        args.iter().position(|arg| arg == "--language").and_then(|idx| args.get(idx + 1));
+    let library_path = args
+        .iter()
+        .position(|arg| arg == "--library")
+        .and_then(|idx| args.get(idx + 1))
+        .expect("specify the library path with --library");
+    let output_dir = args
+        .iter()
+        .position(|arg| arg == "--out-dir")
+        .and_then(|idx| args.get(idx + 1))
+        .expect("--out-dir is required when using --library");
+    match language {
+        Some(lang) if lang == "dart" => {
+            uniffi_dart::gen::generate_dart_bindings(
+                "src/payjoin_ffi.udl".into(),
+                None,
+                Some(output_dir.as_str().into()),
+                library_path.as_str().into(),
+                true,
+            )
+            .expect("Failed to generate dart bindings");
+        }
+        _ => uniffi::uniffi_bindgen_main(),
+    }
 }

--- a/payjoin-ffi/uniffi-bindgen.rs
+++ b/payjoin-ffi/uniffi-bindgen.rs
@@ -1,4 +1,13 @@
 fn main() {
     #[cfg(feature = "uniffi")]
-    uniffi::uniffi_bindgen_main()
+    uniffi::uniffi_bindgen_main();
+    #[cfg(feature = "uniffi")]
+    uniffi_dart::gen::generate_dart_bindings(
+        "src/payjoin_ffi.udl".into(),
+        None,
+        Some("dart/lib".into()),
+        "target/release/libpayjoin_ffi.dylib".into(),
+        true,
+    )
+    .unwrap();
 }


### PR DESCRIPTION
Adds a working Dart FFI integration test workflow for Payjoin, validating the FFI bridge and Bitcoin Core connectivity.

- Please see the README.md in payjoin-ffi/dart/integration_tests/README.md for blocker when running the integration test and temp workaround 